### PR TITLE
chore(ENG-11425): replace semantic-release PAT with GitHub App tokens

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,20 +71,24 @@ jobs:
           architecture: x64
 
       - name: Publish to GH Packages
-        run: |
-          ./gradlew compileJava publish -Pversion="${{ needs.cut-tag.outputs.new_tag }}"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NEW_TAG: ${{ needs.cut-tag.outputs.new_tag }}
+        run: |
+          ./gradlew compileJava publish -Pversion="${NEW_TAG}"
 
       - name: Commit files
+        env:
+          CHANGELOG: ${{ needs.cut-tag.outputs.changelog }}
+          NEW_TAG: ${{ needs.cut-tag.outputs.new_tag }}
         run: |
           git config --local user.email "platform@basistheory.com"
           git config --local user.name "github-actions[bot]"
 
-          echo "${{ needs.cut-tag.outputs.changelog }}" | cat - CHANGELOG.md > temp && mv temp CHANGELOG.md
+          printf '%s\n' "$CHANGELOG" | cat - CHANGELOG.md > temp && mv temp CHANGELOG.md
 
           git add CHANGELOG.md
-          git commit -m "chore(release): updating version and changelog ${{ needs.cut-tag.outputs.new_tag }} [skip ci]" || echo "Nothing to update"
+          git commit -m "chore(release): updating version and changelog ${NEW_TAG} [skip ci]" || echo "Nothing to update"
 
       - name: Push changes
         uses: ad-m/github-push-action@881a6320fdb16eb5318c5054f31c218aec2b324c # master

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,8 +5,39 @@ on:
     branches: [master]
 
 jobs:
-  tag:
-    name: Tag repo
+  cut-tag:
+    name: Cut tag
+    runs-on: ubuntu-latest
+    environment: TAG
+    outputs:
+      new_tag: ${{ steps.tag-version.outputs.new_tag }}
+      release_type: ${{ steps.tag-version.outputs.release_type }}
+      changelog: ${{ steps.tag-version.outputs.changelog }}
+    steps:
+      - name: Mint tag-app token
+        id: tag-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
+        with:
+          app-id: ${{ vars.GH_TAG_APP_ID }}
+          private-key: ${{ secrets.GH_APP_TAG_KEY }}
+
+      - name: Checkout
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+        with:
+          fetch-depth: 0
+
+      - name: Bump version and push tag
+        id: tag-version
+        uses: mathieudutour/github-tag-action@a22cf08638b34d5badda920f9daf6e72c477b07b # v6.2
+        with:
+          github_token: ${{ steps.tag-token.outputs.token }}
+          default_bump: false
+          tag_prefix: ""
+
+  release:
+    name: Publish & write back
+    needs: cut-tag
+    if: ${{ needs.cut-tag.outputs.release_type != '' }}
     runs-on: ubuntu-latest
     environment: PROD
     permissions:
@@ -14,60 +45,56 @@ jobs:
       packages: write
     steps:
       - name: Start Deploy Message
-        uses: Basis-Theory/public-github-actions/deploy-slack-action@master
+        uses: Basis-Theory/public-github-actions/deploy-slack-action@12362db6b1ad6b524d28c47a6489c3e73ecd656a # master
         with:
           slack-api-token: ${{ secrets.SLACK_DUCKBOT_API_KEY }}
           channel: ${{ vars.SLACK_DUCKBOT_RELEASE_CHANNEL_ID }}
 
+      - name: Mint semantic-release app token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
+        with:
+          app-id: ${{ vars.SEMANTIC_RELEASE_APP_ID }}
+          private-key: ${{ secrets.SEMANTIC_RELEASE_APP_PRIVATE_KEY }}
+
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
         with:
           fetch-depth: 0
-          token: ${{ secrets.SEMANTIC_RELEASE_PAT }}
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Set up Java
         id: setup-jre
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@b6e674f4b717d7b0ae3baee0fbe79f498905dfde # v1
         with:
           java-version: "11"
           architecture: x64
 
-      - name: Bump version and push tag
-        id: tag-version
-        uses: mathieudutour/github-tag-action@v6.2
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          default_bump: false
-          tag_prefix: ""
-
       - name: Publish to GH Packages
-        if: ${{ steps.tag-version.outputs.new_tag != '' }}
         run: |
-          ./gradlew compileJava publish -Pversion="${{ steps.tag-version.outputs.new_tag }}"
+          ./gradlew compileJava publish -Pversion="${{ needs.cut-tag.outputs.new_tag }}"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Commit files
-        if: ${{ steps.tag-version.outputs.release_type != '' }}
         run: |
           git config --local user.email "platform@basistheory.com"
           git config --local user.name "github-actions[bot]"
 
-          echo "${{ steps.tag-version.outputs.changelog }}" | cat - CHANGELOG.md > temp && mv temp CHANGELOG.md
+          echo "${{ needs.cut-tag.outputs.changelog }}" | cat - CHANGELOG.md > temp && mv temp CHANGELOG.md
 
           git add CHANGELOG.md
-          git commit -m "chore(release): updating version and changelog ${{ steps.tag-version.outputs.new_tag }} [skip ci]" || echo "Nothing to update"
+          git commit -m "chore(release): updating version and changelog ${{ needs.cut-tag.outputs.new_tag }} [skip ci]" || echo "Nothing to update"
 
       - name: Push changes
-        uses: ad-m/github-push-action@master
-        if: ${{ steps.tag-version.outputs.release_type != '' }}
+        uses: ad-m/github-push-action@881a6320fdb16eb5318c5054f31c218aec2b324c # master
         with:
-          github_token: ${{ secrets.SEMANTIC_RELEASE_PAT }}
+          github_token: ${{ steps.app-token.outputs.token }}
           branch: ${{ github.ref }}
 
       - name: Stop Deploy Message
         if: always()
-        uses: Basis-Theory/public-github-actions/deploy-slack-action@master
+        uses: Basis-Theory/public-github-actions/deploy-slack-action@12362db6b1ad6b524d28c47a6489c3e73ecd656a # master
         with:
           slack-api-token: ${{ secrets.SLACK_DUCKBOT_API_KEY }}
           channel: ${{ vars.SLACK_DUCKBOT_RELEASE_CHANNEL_ID }}


### PR DESCRIPTION
## Description
- Split the single release job into an isolated **cut-tag** job (`environment: TAG`, bt-version-tagger via `create-github-app-token`) and a **write-back/publish** job (bt_semantic_release), passing `new_tag`/`release_type`/`changelog` via job outputs.
- Removes all `GH_SEMANTIC_RELEASE_PAT` / `SEMANTIC_RELEASE_PAT` usage: tag cut by bt-version-tagger; checkout + `ad-m/github-push-action` write-back by bt_semantic_release. Publish step unchanged.
- All actions pinned to commit SHAs.
- Public repo → inlined `create-github-app-token` (no private composite action).

> Merge order: requires github-repository-management Cat 3 PR (TAG env + prod write-back key + branch protection) applied first.

## Business Impact
- Minimal

## Testing required outside of automated testing?
- [x] Not Applicable

### Screenshots (if appropriate):
- [x] Not Applicable

## Rollback / Rollforward Procedure
- [x] Roll Forward
- [ ] Roll Back

## Documentation
ENG-11425

## Reviewer Checklist
- [ ] Description of Change
- [ ] Description of Business Impact
- [ ] Description of outside testing if applicable
- [ ] Description of Roll Forward / Backward Procedure
- [ ] Documentation updated for Change