### PR TITLE
fix(ENG-11425): document two-app release token model

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,6 @@
 name: Release
+# Releases use two GitHub Apps (ENG-11425): bt-version-tagger (TAG env) cuts the
+# tag; bt_semantic_release writes the version bump + changelog back to master.
 
 on:
   push:


### PR DESCRIPTION
## Description
- Add a comment to the release workflow documenting the two-app model introduced in ENG-11425: `bt-version-tagger` (master-restricted `TAG` env) cuts the tag, and `bt_semantic_release` writes the version bump + changelog back to master.
- Uses a `fix:` message intentionally so merging this validates the migrated release pipeline end-to-end — on merge, `github-tag-action` should cut a patch tag via the tagger app and the release job should publish + write back via the semantic-release app.

## Business Impact
- Minimal

## Testing required outside of automated testing?
- [x] Not Applicable

### Screenshots (if appropriate):
- [x] Not Applicable

## Rollback / Rollforward Procedure
- [x] Roll Forward
- [ ] Roll Back

## Documentation
[Link to docs if applicable, or leave empty]

## Reviewer Checklist
- [ ] Description of Change
- [ ] Description of Business Impact
- [ ] Description of outside testing if applicable
- [ ] Description of Roll Forward / Backward Procedure
- [ ] Documentation updated for Change