### PR TITLE
fix(ENG-11425): note GH Packages publish uses native GITHUB_TOKEN

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,6 +72,8 @@ jobs:
           java-version: "11"
           architecture: x64
 
+      # GH Packages publish uses the native GITHUB_TOKEN (packages: write), not an
+      # app token — the app token is only for checkout + the changelog write-back.
       - name: Publish to GH Packages
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Description
- Add a comment clarifying that the GH Packages publish step deliberately uses the native `GITHUB_TOKEN` (`packages: write`), not the `bt_semantic_release` app token — the app token is only for checkout + the changelog write-back.
- Rolls the release forward: the previous validation run cut tag `7.0.1`, but package `7.0.1` already existed in GH Packages (orphaned from history) so the publish 409'd. Merging this `fix:` cuts `7.0.2` (which does not exist) and publishes cleanly, exercising the full pipeline including the changelog write-back via the app token.

## Business Impact
- Minimal

## Testing required outside of automated testing?
- [x] Not Applicable

### Screenshots (if appropriate):
- [x] Not Applicable

## Rollback / Rollforward Procedure
- [x] Roll Forward
- [ ] Roll Back

## Documentation
[Link to docs if applicable, or leave empty]

## Reviewer Checklist
- [ ] Description of Change
- [ ] Description of Business Impact
- [ ] Description of outside testing if applicable
- [ ] Description of Roll Forward / Backward Procedure
- [ ] Documentation updated for Change